### PR TITLE
Fix: RuntimeError: CRC Mismatch / ATECC608A not reachable via I2C anymore

### DIFF
--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -115,7 +115,7 @@ Configuration Zone Bytes
 Serial Number (Bytes 0-3 and 8-12), Revision Number (Bytes 4-7)
 AES Enable (Byte 13), I2C Enable (Byte 14), Reserved (Byte 15)
 I2C Address (Byte 16), Reserved (Byte 17); Count Match (Byte 18)
-Chi Mode (Byte 19), Slot Config (Bytes 20-51)
+Chip Mode (Byte 19), Slot Config (Bytes 20-51)
 Counter 0 (Bytes 52-59), Counter 1 (Bytes 60-67)
 Use Lock (Byte 68), Volatile Key Permission (Byte 69)
 Secure Boot (Bytes 70-71), KDF (Bytes 72-74)

--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -155,7 +155,7 @@ CFG_TLS_HEX = bytes(
 # TODO: Decide whether to use alternate representation of config bytes
 # TODO: Remove assertion tests
 assert CFG_TLS == CFG_TLS_HEX
-assert bytearray(CFG_TLS)[16] == 0x20  #
+assert bytearray(CFG_TLS)[16] == 0x20
 
 # Convert I2C address to config byte 16 and update CFG_TLS
 _CFG_BYTES = bytearray(CFG_TLS)

--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -128,7 +128,7 @@ I2C Config
          HEX    DEC     BIN         Description
 Byte 14: C0     192     1100 0000
                         ^xxx xxxx   Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip
-Byte 16: C0     192     0010 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
+Byte 16: C0     192     1100 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
 Byte 16: 6A     106     0110 1010   Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS
 Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN
 """

--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -110,6 +110,8 @@ CFG_TLS = b"\x01#\x00\x00\x00\x00P\x00\x00\x00\x00\x00\x00\xc0q\x00 \
             \x00<\x00<\x00<\x00\x1c\x00"
 
 """
+Configuration Zone Bytes
+
 Serial Number (Bytes 0-3 and 8-12), Revision Number (Bytes 4-7)
 AES Enable (Byte 13), I2C Enable (Byte 14), Reserved (Byte 15)
 I2C Address (Byte 16), Reserved (Byte 17); Count Match (Byte 18)
@@ -120,6 +122,15 @@ Secure Boot (Bytes 70-71), KDF (Bytes 72-74)
 Reserved (Bytes 75-83), User Extra (Bytes 84-85)
 Lock Config (Bytes 86-89), Chip Options (Bytes 90-91)
 X509 (Bytes 92-95), Key Config (Bytes 96-127)
+
+I2C Config
+
+         HEX    DEC     BIN         Description
+Byte 14: C0     192     1100 0000
+                        ^xxx xxxx   Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip
+Byte 16: C0     192     0010 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
+Byte 16: 6A     106     0110 1010   Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS
+Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN
 """
 CFG_TLS_HEX = bytes(
     bytearray.fromhex(
@@ -144,16 +155,7 @@ CFG_TLS_HEX = bytes(
 # TODO: Decide whether to use alternate representation of config bytes
 # TODO: Remove assertion tests
 assert CFG_TLS == CFG_TLS_HEX
-assert bytearray(CFG_TLS)[16] == 0x20  #
-
-"""I2C Config
-         HEX    DEC     BIN         Description
-Byte 14: C0     192     1100 0000
-                        ^xxx xxxx   Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip
-Byte 16: C0     192     0010 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
-Byte 16: 6A     106     0010 0000   Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS
-Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN
-"""
+assert bytearray(CFG_TLS)[16] == 0x20
 
 # Convert I2C address to config byte 16 and update CFG_TLS
 _CFG_BYTES = bytearray(CFG_TLS)

--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -134,20 +134,20 @@ Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATE
 """
 CFG_TLS_HEX = bytes(
     bytearray.fromhex(
-        '01 23 00 00 00 00 50 00  00 00 00 00 00 c0 71 00'
-        '20 20 20 20 20 20 20 20  20 20 20 20 20 c0 00 55'
-        '00 83 20 87 20 87 20 87  2f 87 2f 8f 8f 9f 8f af'
-        '20 20 20 20 20 20 20 20  20 20 20 20 20 8f 00 00'
-        '00 00 00 00 00 00 00 00  00 00 00 00 20 20 20 20'
-        '20 20 20 20 20 20 20 20  20 af 8f ff ff ff ff 00'
-        '00 00 00 ff ff ff ff 00  20 20 20 20 20 20 20 20'
-        '20 20 20 20 20 00 00 00  ff ff ff ff ff ff ff ff'
-        'ff ff ff ff 20 20 20 20  20 20 20 20 20 20 20 20'
-        '20 ff ff ff ff 00 00 55  55 ff ff 00 00 00 00 00'
-        '00 33 20 20 20 20 20 20  20 20 20 20 20 20 20 00'
-        '33 00 33 00 33 00 33 00  1c 00 1c 00 1c 00 3c 00'
-        '3c 00 3c 00 3c 20 20 20  20 20 20 20 20 20 20 20'
-        '20 20 00 3c 00 3c 00 3c  00 1c 00'
+        "01 23 00 00 00 00 50 00  00 00 00 00 00 c0 71 00"
+        "20 20 20 20 20 20 20 20  20 20 20 20 20 c0 00 55"
+        "00 83 20 87 20 87 20 87  2f 87 2f 8f 8f 9f 8f af"
+        "20 20 20 20 20 20 20 20  20 20 20 20 20 8f 00 00"
+        "00 00 00 00 00 00 00 00  00 00 00 00 20 20 20 20"
+        "20 20 20 20 20 20 20 20  20 af 8f ff ff ff ff 00"
+        "00 00 00 ff ff ff ff 00  20 20 20 20 20 20 20 20"
+        "20 20 20 20 20 00 00 00  ff ff ff ff ff ff ff ff"
+        "ff ff ff ff 20 20 20 20  20 20 20 20 20 20 20 20"
+        "20 ff ff ff ff 00 00 55  55 ff ff 00 00 00 00 00"
+        "00 33 20 20 20 20 20 20  20 20 20 20 20 20 20 00"
+        "33 00 33 00 33 00 33 00  1c 00 1c 00 1c 00 3c 00"
+        "3c 00 3c 00 3c 20 20 20  20 20 20 20 20 20 20 20"
+        "20 20 00 3c 00 3c 00 3c  00 1c 00"
     )
 )
 
@@ -319,7 +319,7 @@ class ATECC:
         time.sleep(1 / 1000)
         if mode == 0x03:
             assert (
-                    calculated_nonce[0] == 0x00
+                calculated_nonce[0] == 0x00
             ), "Incorrectly calculated nonce in pass-thru mode"
         self.idle()
         return calculated_nonce
@@ -489,7 +489,7 @@ class ATECC:
             if i == 84:
                 # can't write
                 continue
-            self._write(0, i // 4, data[i: i + 4])
+            self._write(0, i // 4, data[i : i + 4])
 
     def _write(self, zone, address, buffer):
         self.wakeup()

--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -52,8 +52,20 @@ from adafruit_binascii import hexlify
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ATECC.git"
 
+
+def _convert_i2c_addr_to_atecc_addr(i2c_addr=0x60):
+    int(i2c_addr, 16)
+    return i2c_addr << 1
+
+
 # Device Address
-_REG_ATECC_ADDR = const(0xC0)
+_I2C_ADDR = 0x60
+_REG_ATECC_ADDR = _convert_i2c_addr_to_atecc_addr(i2c_addr=_I2C_ADDR)
+
+# TODO: Verify that _REG_ATECC_ADDR is still 0xC0
+# TODO: Remove assertion test afterwards
+assert _REG_ATECC_ADDR == 0xC0
+
 _REG_ATECC_DEVICE_ADDR = _REG_ATECC_ADDR >> 1
 
 # Version Registers
@@ -88,7 +100,6 @@ EXEC_TIME = {
     OP_WRITE: const(26),
 }
 
-
 CFG_TLS = b"\x01#\x00\x00\x00\x00P\x00\x00\x00\x00\x00\x00\xc0q\x00 \
             \xc0\x00U\x00\x83 \x87 \x87 \x87/\x87/\x8f\x8f\x9f\x8f\xaf \
             \x8f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 \
@@ -97,6 +108,58 @@ CFG_TLS = b"\x01#\x00\x00\x00\x00P\x00\x00\x00\x00\x00\x00\xc0q\x00 \
             \xff\xff\xff\xff\x00\x00UU\xff\xff\x00\x00\x00\x00\x00\x003 \
             \x003\x003\x003\x003\x00\x1c\x00\x1c\x00\x1c\x00<\x00<\x00<\x00< \
             \x00<\x00<\x00<\x00\x1c\x00"
+
+"""
+Serial Number (Bytes 0-3 and 8-12), Revision Number (Bytes 4-7)
+AES Enable (Byte 13), I2C Enable (Byte 14), Reserved (Byte 15)
+I2C Address (Byte 16), Reserved (Byte 17); Count Match (Byte 18)
+Chi Mode (Byte 19), Slot Config (Bytes 20-51)
+Counter 0 (Bytes 52-59), Counter 1 (Bytes 60-67)
+Use Lock (Byte 68), Volatile Key Permission (Byte 69)
+Secure Boot (Bytes 70-71), KDF (Bytes 72-74)
+Reserved (Bytes 75-83), User Extra (Bytes 84-85)
+Lock Config (Bytes 86-89), Chip Options (Bytes 90-91)
+X509 (Bytes 92-95), Key Config (Bytes 96-127)
+"""
+CFG_TLS_HEX = bytes(
+    bytearray.fromhex(
+        '01 23 00 00 00 00 50 00  00 00 00 00 00 c0 71 00'
+        '20 20 20 20 20 20 20 20  20 20 20 20 20 c0 00 55'
+        '00 83 20 87 20 87 20 87  2f 87 2f 8f 8f 9f 8f af'
+        '20 20 20 20 20 20 20 20  20 20 20 20 20 8f 00 00'
+        '00 00 00 00 00 00 00 00  00 00 00 00 20 20 20 20'
+        '20 20 20 20 20 20 20 20  20 af 8f ff ff ff ff 00'
+        '00 00 00 ff ff ff ff 00  20 20 20 20 20 20 20 20'
+        '20 20 20 20 20 00 00 00  ff ff ff ff ff ff ff ff'
+        'ff ff ff ff 20 20 20 20  20 20 20 20 20 20 20 20'
+        '20 ff ff ff ff 00 00 55  55 ff ff 00 00 00 00 00'
+        '00 33 20 20 20 20 20 20  20 20 20 20 20 20 20 00'
+        '33 00 33 00 33 00 33 00  1c 00 1c 00 1c 00 3c 00'
+        '3c 00 3c 00 3c 20 20 20  20 20 20 20 20 20 20 20'
+        '20 20 00 3c 00 3c 00 3c  00 1c 00'
+    )
+)
+
+# TODO: Verify that both representations are identical
+# TODO: Decide whether to use alternate representation of config bytes
+# TODO: Remove assertion tests
+assert CFG_TLS == CFG_TLS_HEX
+assert bytearray(CFG_TLS)[16] == 0x20  #
+
+"""I2C Config
+         HEX    DEC     BIN         Description
+Byte 14: C0     192     1100 0000
+                        ^xxx xxxx   Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip
+Byte 16: C0     192     0010 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
+Byte 16: 6A     106     0010 0000   Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS
+Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN
+"""
+
+# Convert I2C address to config byte 16 and update CFG_TLS
+_CFG_BYTES = bytearray(CFG_TLS)
+_CFG_BYTE_16 = hex(_I2C_ADDR << 1)
+_CFG_BYTES[16] = ord(_CFG_BYTE_16)
+CFG_TLS = bytes(_CFG_BYTES)
 
 
 class ATECC:
@@ -254,7 +317,7 @@ class ATECC:
         time.sleep(1 / 1000)
         if mode == 0x03:
             assert (
-                calculated_nonce[0] == 0x00
+                    calculated_nonce[0] == 0x00
             ), "Incorrectly calculated nonce in pass-thru mode"
         self.idle()
         return calculated_nonce
@@ -424,7 +487,7 @@ class ATECC:
             if i == 84:
                 # can't write
                 continue
-            self._write(0, i // 4, data[i : i + 4])
+            self._write(0, i // 4, data[i: i + 4])
 
     def _write(self, zone, address, buffer):
         self.wakeup()

--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -110,6 +110,8 @@ CFG_TLS = b"\x01#\x00\x00\x00\x00P\x00\x00\x00\x00\x00\x00\xc0q\x00 \
             \x00<\x00<\x00<\x00\x1c\x00"
 
 """
+Configuration Zone Bytes
+
 Serial Number (Bytes 0-3 and 8-12), Revision Number (Bytes 4-7)
 AES Enable (Byte 13), I2C Enable (Byte 14), Reserved (Byte 15)
 I2C Address (Byte 16), Reserved (Byte 17); Count Match (Byte 18)
@@ -120,6 +122,15 @@ Secure Boot (Bytes 70-71), KDF (Bytes 72-74)
 Reserved (Bytes 75-83), User Extra (Bytes 84-85)
 Lock Config (Bytes 86-89), Chip Options (Bytes 90-91)
 X509 (Bytes 92-95), Key Config (Bytes 96-127)
+
+I2C Config
+
+         HEX    DEC     BIN         Description
+Byte 14: C0     192     1100 0000
+                        ^xxx xxxx   Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip
+Byte 16: C0     192     0010 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
+Byte 16: 6A     106     0110 1010   Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS
+Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN
 """
 CFG_TLS_HEX = bytes(
     bytearray.fromhex(
@@ -145,15 +156,6 @@ CFG_TLS_HEX = bytes(
 # TODO: Remove assertion tests
 assert CFG_TLS == CFG_TLS_HEX
 assert bytearray(CFG_TLS)[16] == 0x20  #
-
-"""I2C Config
-         HEX    DEC     BIN         Description
-Byte 14: C0     192     1100 0000
-                        ^xxx xxxx   Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip
-Byte 16: C0     192     0010 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
-Byte 16: 6A     106     0010 0000   Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS
-Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN
-"""
 
 # Convert I2C address to config byte 16 and update CFG_TLS
 _CFG_BYTES = bytearray(CFG_TLS)


### PR DESCRIPTION
- Fix for adafruit/Adafruit_CircuitPython_ATECC#16
- According to ATECC608A datasheet, the config byte 16 is indeed wrong and sets I2C address 0x10
- Personalization of ATECC608 not tested as I have no unprovisioned/spare modules left
- Added documentation for i2c config byte 16
- Added I2C address variable used to derive config byte 16
- Added I2C address to config byte 16 of CFG_TLS
- Modified representation of CFG_TLS