### PR TITLE
fixing docs API section and resolve sphinx errors to get docs rendering

### DIFF
--- a/adafruit_atecc/adafruit_atecc.py
+++ b/adafruit_atecc/adafruit_atecc.py
@@ -36,13 +36,14 @@ Implementation Notes
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
 
- * Adafruit Bus Device library:
+* Adafruit Bus Device library:
   https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 
- * Adafruit binascii library:
+* Adafruit binascii library:
   https://github.com/adafruit/Adafruit_CircuitPython_binascii
 
 """
+
 import time
 from struct import pack
 
@@ -106,6 +107,7 @@ EXEC_TIME = {
     OP_WRITE: const(26),
 }
 
+# pylint: disable=line-too-long
 """
 Configuration Zone Bytes
 
@@ -122,13 +124,21 @@ X509 (Bytes 92-95), Key Config (Bytes 96-127)
 
 I2C Config
 
-         HEX    DEC     BIN         Description
-Byte 14: C0     192     1100 0000
-                        ^xxx xxxx   Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip
-Byte 16: C0     192     1100 0000   Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA
-Byte 16: 6A     106     0110 1010   Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS
-Byte 16: 20      32     0010 0000   Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN
++------+-------+---------+-------------+---------------------------------------------------------------+
+| HEX          | DEC     | BIN         | Description                                                   |
++======+=======+=========+=============+===============================================================+
+| Byte 14: C0  |   192   |  1100 0000  |                                                               |
+|              |         |   ^xxx xxxx |  Bit 0 (MSB): 0:Single Wire, 1:I2C; Bit 1-7: Set by Microchip |
++--------------+---------+-------------+---------------------------------------------------------------+
+| Byte 16: C0  |  192    | 1100 0000   | Default 7 bit I2C Address: 0xC0>>1: 0x60 ATECC608A-MAHDA      |
++--------------+---------+-------------+---------------------------------------------------------------+
+| Byte 16: 6A  |  106    | 0110 1010   | Default 7 bit I2C Address: 0x6A>>1: 0x35 ATECC608A-TNGTLS     |
++--------------+---------+-------------+---------------------------------------------------------------+
+| Byte 16: 20  |    32   |  0010 0000  | Default 7 bit I2C Address: 0x20>>1: 0x10 ATECC608A-UNKNOWN    |
++--------------+---------+-------------+---------------------------------------------------------------+
+
 """
+
 CFG_TLS = bytes(
     bytearray(
         unhexlify(

--- a/adafruit_atecc/adafruit_atecc_asn1.py
+++ b/adafruit_atecc/adafruit_atecc_asn1.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
-`atecc_asn1`
+`adafruit_atecc_asn1`
 ================================================================================
 
 ASN.1 Utilities for the Adafruit_ATECC Module.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,3 +7,12 @@ API
 
 .. automodule:: adafruit_atecc
    :members:
+
+.. automodule:: adafruit_atecc.adafruit_atecc
+   :members:
+
+.. automodule:: adafruit_atecc.adafruit_atecc_asn1
+   :members:
+
+.. automodule:: adafruit_atecc.adafruit_atecc_cert_util
+   :members:


### PR DESCRIPTION
These are the minimal changes needed in order to get the docs page to include the actual API for the library. 

I added rst table syntax to one section as well so it would properly render the data contained in that comment.