### PR TITLE
required fix for circuit python 8.2.x ATECC crypto module

### DIFF
--- a/examples/atecc_simpletest.py
+++ b/examples/atecc_simpletest.py
@@ -5,8 +5,12 @@ import board
 import busio
 from adafruit_atecc.adafruit_atecc import ATECC, _WAKE_CLK_FREQ
 
+# Set the module wake frequency ping (default 100000)
+atecc_wake_frequency = _WAKE_CLK_FREQ
+# atecc_wake_frequency = 75000  # Recommend 75000 if 100000 does not work
+
 # Initialize the i2c bus
-i2c = busio.I2C(board.SCL, board.SDA, frequency=_WAKE_CLK_FREQ)
+i2c = busio.I2C(board.SCL, board.SDA, frequency=atecc_wake_frequency)
 
 # Initialize a new atecc object
 atecc = ATECC(i2c)


### PR DESCRIPTION
Wake frequency 100000 causes CRC Mismatch failure. setting frequency to 75000 works. confirmed on rp2040 feather and esp32-s3 feather.

With default 100000 wake frequency
```py
Traceback (most recent call last):
  File "code.py", line 16, in <module>
  File "/lib/adafruit_atecc/adafruit_atecc.py", line 192, in __init__
  File "/lib/adafruit_atecc/adafruit_atecc.py", line 266, in version
  File "/lib/adafruit_atecc/adafruit_atecc.py", line 301, in info
  File "/lib/adafruit_atecc/adafruit_atecc.py", line 625, in _get_response
RuntimeError: CRC Mismatch
```
With frequency at 75000 wake frequency (any value from 1 to 79999 works)
```py
ATECC Serial:  0123xxxxobfuscated
Random Value:  obfuscated
ATECC Counter #1 Value:  bytearray(b'obfuscated')
Appending to the digest...
Appending to the digest...
SHA Digest:  bytearray(b'obfuscated')

Code done running.
```
The simpletest is broken on most if not all microcontrollers with the current stable 8.2.10 circuit python due to the default wake frequency being too high. I've added a code commented frequency if the default 100000 value doesn't work they'll have a code commented alternative to try.