### PR TITLE
Fixed dangling else: in issuer_or_subject_length()

### DIFF
--- a/adafruit_atecc/adafruit_atecc_asn1.py
+++ b/adafruit_atecc/adafruit_atecc_asn1.py
@@ -269,6 +269,6 @@ def issuer_or_subject_length(
         tot_len += 11 + len(org_unit)
     if common:
         tot_len += 11 + len(common)
-    else:
+    if tot_len == 0:
         raise TypeError("Provided length must be > 0")
     return tot_len


### PR DESCRIPTION
Changed the `else` to an `if tot_len == 0:` to match the doctring's listed functionality "raises: TypeError if return value is 0".  The previous code would raise `TypeError` if the parameter `common` was falsy.  It now raises the error if `tot_len` is zero.
