### PR TITLE
Fix dangling else in issuer_or_subject_length (issue #30)

### DIFF
--- a/adafruit_atecc/adafruit_atecc_asn1.py
+++ b/adafruit_atecc/adafruit_atecc_asn1.py
@@ -268,6 +268,6 @@ def issuer_or_subject_length(
         tot_len += 11 + len(org_unit)
     if common:
         tot_len += 11 + len(common)
-    else:
-        raise TypeError("Provided length must be > 0")
+    if tot_len == 0:
+        raise TypeError("issuer_or_subject_length cannot be zero")
     return tot_len


### PR DESCRIPTION
This pull request fixes the logic in adafruit_atecc/adafruit_atecc_asn1.py where the issuer_or_subject_length function incorrectly raised a TypeError whenever the common parameter was empty. The previous implementation had a dangling else: attached to the if common block, so an error was raised even when other fields were provided.

The fix removes the dangling else and instead raises a TypeError only when no certificate fields have been supplied (i.e., when tot_len == 0). This behaviour matches the intended functionality described in issue #30.

This PR therefore resolves #30.